### PR TITLE
Read embossed metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
+
+[[package]]
 name = "clap"
 version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,10 +198,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "emboss"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9d96d2ff99717092d08015e9ba42854bae5cbb299ee5c2433554433f1ee1f3"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "enum-iterator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c79a6321a1197d7730510c7e3f6cb80432dfefecb32426de8cea0aa19b4bb8d7"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "flate2"
@@ -228,6 +267,18 @@ name = "foreign-types-shared"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7684cf33bb7f28497939e8c7cf17e3e4e3b8d9a0080ffa4f8ae2f515442ee855"
+
+[[package]]
+name = "getset"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b328c01a4d71d2d8173daa93562a73ab0fe85616876f02500f53d82948c504"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "hashbrown"
@@ -313,6 +364,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +413,15 @@ name = "os_str_bytes"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "pkg-config"
@@ -434,13 +513,14 @@ checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "rsps"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "ansi_term",
  "anyhow",
  "byte-unit",
  "clap",
  "console",
+ "emboss",
  "lazy_static",
  "object",
  "rayon",
@@ -448,6 +528,7 @@ dependencies = [
  "rustc-demangle",
  "sysinfo",
  "tabwriter",
+ "vergen",
 ]
 
 [[package]]
@@ -469,10 +550,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "strsim"
@@ -547,6 +661,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,10 +749,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "vergen"
+version = "5.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf0b57f76a4f7e9673db1e7ffa4541d215ae8336fee45f5c1378bdeb22a0314"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "chrono",
+ "enum-iterator",
+ "getset",
+ "rustc_version",
+ "rustversion",
+ "thiserror",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,20 @@
 [package]
 name = "rsps"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Matt Stavola <matt@stavola.xyz>"]
 edition = "2018"
 description = "A command line tool to list and debug running Rust processes"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/mbStavola/rsps/"
 categories = ["command-line-utilities", "development-tools"]
+build = "build.rs"
 
 [[bin]]
 name = "rsps"
 path = "src/main.rs"
+
+[build-dependencies]
+vergen = { version = "5", default-features = false, features = ["build", "cargo", "rustc"] }
 
 [dependencies]
 clap = "3.0.0-beta.2"
@@ -24,6 +28,7 @@ anyhow = "1.0.40"
 rustc-demangle = "0.1.18"
 byte-unit = { version = "4.0.10", default-features = false, features = ["std"] }
 tabwriter = { version = "1.2.1", features = ["ansi_formatting"] }
+emboss = "0.3.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rstack = "0.3.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.51-buster
+FROM rust:1.52-buster
 
 RUN mkdir /usr/src/app
 WORKDIR /usr/src/app
@@ -13,5 +13,6 @@ RUN mkdir .cargo
 RUN cargo vendor > .cargo/config.toml
 
 ADD ./src ./src
+COPY ./build.rs .
 
 RUN cargo build

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Crates.io](https://img.shields.io/crates/v/rsps)
 
-A command line tool to help find and debug Rust programs on your machine. Inspired by [gops][1] and a fit of boredom.
+A command line tool to help find and debug Rust programs on your machine. Inspired by [gops][gops] and a fit of boredom.
 
 This only works if the binaries haven't be stripped beforehand.
 
@@ -20,9 +20,9 @@ Lists all running Rust processes.
 
 ```bash
 $ rsps # or rsps list
-PID    Parent  Name  Path
-58988  54401   rg    /usr/local/bin/rg
-58989  47182   rsps  target/debug/rsps
+PID    Parent  Name  Command            Rust Ver.  Program Ver.
+34107  10940   rsps  target/debug/rsps  1.52.1     0.3.1
+34106  11719   rg    /usr/local/bin/rg  <unknown>  <unknown>
 ```
 
 ## Tree
@@ -60,6 +60,24 @@ Name: cargo
 Command: /Users/matt/.rustup/toolchains/stable-x86_64-apple-darwin/bin/cargo
 CPU Usage: 6.57%
 Memory Usage: 24.66 MiB (1.11%)
+```
+
+If the process has used the [emboss][emboss] crate, some additional information may be displayed:
+
+```bash
+PID: 34015
+Parent: 10940
+User: matt
+Name: rsps
+Command: target/debug/rsps
+CPU Usage: 315.58%
+Memory Usage: 21.92 MiB (1.75%)
+
+Rust Version: 1.52.1
+Program Version: 0.3.1
+Cargo Build Profile: debug
+Cargo Features: default
+Build Timestamp: 2021-05-26T23:45:47.849240+00:00
 ```
 
 ## Stack (Linux only)
@@ -106,16 +124,16 @@ Frame #7: <no symbol>
 [...]
 ```
 
-Currently limited to Linux only due to [rstack][2] only building on Linux.
+Currently limited to Linux only due to [rstack][rstack] only building on Linux.
 
 # License
 
 Licensed under either of
 
 * Apache License, Version 2.0
-  ([LICENSE-APACHE][3] or http://www.apache.org/licenses/LICENSE-2.0)
+  ([LICENSE-APACHE][apache-license] or http://www.apache.org/licenses/LICENSE-2.0)
 * MIT license
-  ([LICENSE-MIT][4] or http://opensource.org/licenses/MIT)
+  ([LICENSE-MIT][mit-license] or http://opensource.org/licenses/MIT)
 
 at your option.
 
@@ -125,7 +143,8 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
-[1]: https://github.com/google/gops
-[2]: https://github.com/sfackler/rstack
-[3]: ./LICENSE-APACHE
-[4]: ./LICENSE-MIT
+[gops]: https://github.com/google/gops
+[emboss]: https://github.com/mbStavola/emboss
+[rstack]: https://github.com/sfackler/rstack
+[apache-license]: ./LICENSE-APACHE
+[mit-license]: ./LICENSE-MIT

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+use vergen::{vergen, Config};
+
+fn main() -> Result<(), ()> {
+    let config = Config::default();
+    vergen(config).unwrap();
+
+    Ok(())
+}

--- a/src/commands/stack.rs
+++ b/src/commands/stack.rs
@@ -16,7 +16,7 @@ pub struct StackCommand {
 
 impl RspsSubcommand for StackCommand {
     fn exec(&self, system: &mut System, tw: &mut TabWriter<Vec<u8>>) -> Result<()> {
-        let process = self.process.as_system_process(system, tw)?;
+        let (process, _) = self.process.as_system_process(system, tw)?;
 
         let mut tracer = TraceOptions::new();
         tracer

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 
 use anyhow::Result;
 use clap::{AppSettings, Clap};
+use emboss::emboss;
 use sysinfo::{RefreshKind, SystemExt};
 use tabwriter::TabWriter;
 
@@ -10,7 +11,12 @@ use crate::commands::StackCommand;
 use crate::commands::{InspectCommand, ListCommand, RspsSubcommand, TreeCommand};
 
 mod commands;
+mod rsinfo;
 mod util;
+
+// Embed some build information into the final binary that
+// can be used by rsps... wait isn't that us?
+emboss!(group = rsps);
 
 /// List and debug Rust programs currently running on your system.
 #[derive(Clap)]

--- a/src/rsinfo.rs
+++ b/src/rsinfo.rs
@@ -1,0 +1,68 @@
+use std::{borrow::Cow, convert::TryFrom};
+
+use object::{Object, ObjectSection};
+
+#[derive(Default)]
+pub struct RsInfo {
+    build_time: Option<String>,
+    program_version: Option<String>,
+    rust_version: Option<String>,
+    build_profile: Option<String>,
+    cargo_features: Option<String>,
+}
+
+impl RsInfo {
+    pub fn build_time(&self) -> Option<&String> {
+        self.build_time.as_ref()
+    }
+
+    pub fn program_version(&self) -> Option<&String> {
+        self.program_version.as_ref()
+    }
+
+    pub fn rust_version(&self) -> Option<&String> {
+        self.rust_version.as_ref()
+    }
+
+    pub fn build_profile(&self) -> Option<&String> {
+        self.build_profile.as_ref()
+    }
+
+    pub fn cargo_features(&self) -> Option<&String> {
+        self.cargo_features.as_ref()
+    }
+
+    pub fn has_content(&self) -> bool {
+        self.build_time
+            .as_ref()
+            .or(self.program_version.as_ref())
+            .or(self.rust_version.as_ref())
+            .or(self.build_profile.as_ref())
+            .or(self.cargo_features.as_ref())
+            .is_some()
+    }
+}
+
+impl TryFrom<&object::File<'_>> for RsInfo {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &object::File<'_>) -> Result<Self, Self::Error> {
+        let section = value.section_by_name(emboss::DEFAULT_SECTION_NAME);
+        if section.is_none() {
+            return Ok(RsInfo::default());
+        }
+
+        let section = section.unwrap();
+        let data = section.data()?;
+
+        let metadata = emboss::extract_metadata(data)?;
+
+        Ok(RsInfo {
+            build_time: metadata.get("VERGEN_BUILD_TIMESTAMP").map(Cow::to_string),
+            program_version: metadata.get("VERGEN_BUILD_SEMVER").map(Cow::to_string),
+            rust_version: metadata.get("VERGEN_RUSTC_SEMVER").map(Cow::to_string),
+            build_profile: metadata.get("VERGEN_CARGO_PROFILE").map(Cow::to_string),
+            cargo_features: metadata.get("VERGEN_CARGO_FEATURES").map(Cow::to_string),
+        })
+    }
+}


### PR DESCRIPTION
# Context

Take advantage of the [emboss](https://github.com/mbStavola/emboss) crate to read metadata embedded in Rust binaries.

In other words, we can tell what version of Rust was used to compile a particular Rust binary (among other things)... provided that binary also uses `emboss`.

# Technical

Most of the "heavy" lifting is done in the `emboss` crate. We just extract the metadata and print it out.

We also get a neat "fast" path with `emboss` since we now don't necessarily need to scan every symbol to determine if a binary is compiled with Rust. This is because if we can find `emboss` metadata then it's a pretty sure bet that this is a Rust program considering the fact that `emboss` is a Rust crate 😄 